### PR TITLE
add 'mrkdwn_in' to Attachement

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "slack-scala-bot-core"
 
-version := "0.2.1"
+version := "0.2.2"
 
 scalaVersion := "2.11.6"
 

--- a/src/main/scala/io/scalac/slack/common/JsonProtocols.scala
+++ b/src/main/scala/io/scalac/slack/common/JsonProtocols.scala
@@ -8,7 +8,7 @@ import spray.json._
 object JsonProtocols extends DefaultJsonProtocol {
 
   implicit object AttachmentFormatWriter extends RootJsonWriter[Attachment] {
-    val attachmentFormat = jsonFormat7(Attachment.apply)
+    val attachmentFormat = jsonFormat8(Attachment.apply)
 
     override def write(a: Attachment): JsValue = {
       JsObject(JsObject("fallback" -> JsString("wrong formatted message")).fields ++ a.toJson(attachmentFormat).asJsObject.fields)

--- a/src/main/scala/io/scalac/slack/common/Messages.scala
+++ b/src/main/scala/io/scalac/slack/common/Messages.scala
@@ -81,7 +81,7 @@ case class ImageUrl(url: String) extends RichMessageElement
 
 case class RichOutboundMessage(channel: String, elements: List[Attachment]) extends MessageEvent
 
-case class Attachment(text: Option[String] = None, pretext: Option[String] = None, fields: Option[List[Field]] = None, title: Option[String] = None, title_link: Option[String] = None, color: Option[String] = None, image_url: Option[String] = None) {
+case class Attachment(text: Option[String] = None, pretext: Option[String] = None, fields: Option[List[Field]] = None, title: Option[String] = None, title_link: Option[String] = None, color: Option[String] = None, image_url: Option[String] = None, mrkdwn_in: Option[List[String]] = None) {
   def isValid = text.isDefined || pretext.isDefined || title.isDefined || (fields.isDefined && fields.get.nonEmpty)
 
   def addElement(element: RichMessageElement): Attachment = {


### PR DESCRIPTION
After https://api.slack.com/docs/formatting:
"...by default bot message text will be formatted, but attachments are not. To disable formatting on a non-user message, set the mrkdwn property to false. To enable formatting on attachment fields, set the mrkdwn_in array on each attachment to the list of fields to process..."
